### PR TITLE
update etcd Stable to v3.3.18 on dev

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: etcd
   sub_title: Distributed reliable key-value store
   project_url: "https://github.com/etcd-io/etcd"
-  stable_ref: "v3.2.28"
+  stable_ref: "v3.3.18"
   head_ref: "master"
   ci_system:
     -


### PR DESCRIPTION
v3.3.18 was released on Nov 26, 2019

- enable v 3.3.18 on dev