### PR TITLE
update etcd project details

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,14 +1,14 @@
  project:
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/etcd/icon/color/etcd-icon-color.svg?sanitize=true"
   display_name: etcd
-  sub_title: Distributed reliable key-value store
+  sub_title: Key/Value Store
   project_url: "https://github.com/etcd-io/etcd"
   stable_ref: "v3.3.18"
   head_ref: "master"
   ci_system:
     -
       ci_system_type: "travis-ci"
-      ci_project_url: "https://example.com/etcd-io/etcd"  # can be anything for citest
+      ci_project_url: "https://travis-ci.com/etcd-io/etcd"
       ci_project_name: "etcd-io/etcd"
       arch:
         - amd64


### PR DESCRIPTION
## Description
1. Update etcd project details
   a. Change subtitle to match wording on https://www.cncf.io/sandbox-projects/ (subtitle on cncf.ci is limited to 21 characters) >  `sub_title: Key/Value Store`
   b. Change ci_project_url from `example.com` to `"https://travis-ci.com/etcd-io/etcd"`

## Issues:
- https://github.com/crosscloudci/crosscloudci/issues/209
- https://github.com/vulk/cncf_ci/issues/306

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against
   * [ ] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [ ]  Browser tested on staging.cncf.ci
* [x]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [x]  My change requires a change to the documentation. 
> Suggestions: to re-use the sub-title from https://www.cncf.io/projects/, to add the project's actual CI system URL, remove the note `# can be anything for citest` from the docs
* [ ]  I have updated the documentation accordingly.
* [ ] No updates required.