### PR TITLE
Update stable v3.4.10 on staging from master

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: etcd
   sub_title: Key/Value Store
   project_url: "https://github.com/etcd-io/etcd"
-  stable_ref: "v3.4.9"
+  stable_ref: "v3.4.10"
   head_ref: "master"
   ci_system:
     -

--- a/cncfci.yml
+++ b/cncfci.yml
@@ -1,14 +1,15 @@
  project:
   logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/etcd/icon/color/etcd-icon-color.svg?sanitize=true"
   display_name: etcd
-  sub_title: Distributed reliable key-value store
+  sub_title: Key/Value Store
   project_url: "https://github.com/etcd-io/etcd"
-  stable_ref: "v3.2.28"
+  stable_ref: "v3.3.18"
   head_ref: "master"
   ci_system:
     -
-      ci_system_type: "travis-ci"
-      ci_project_url: "https://example.com/etcd-io/etcd"  # can be anything for citest
+      ci_system_type: "travis-ci-com"
+      ci_project_url: "https://travis-ci.com/etcd-io/etcd"
       ci_project_name: "etcd-io/etcd"
       arch:
         - amd64
+


### PR DESCRIPTION
## Description
  - v3.4.10 was released on 07-16-2020
  - update stable on staging
  - this release is the same as v3.4.9, travis-ci was released as stable but has a one failed status, making overall status failed. since we do dummy builds, can push as is for now.

## Issues:

 https://github.com/vulk/cncf_ci/issues/344

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x] Manually tested on dev.cncf.ci
 - [x]  Tested with trigger client against
   - [ ]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [ ]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [ ]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required
