### PR TITLE
Update etcd stable to v3.4.13 on production

### DIFF
--- a/cncfci.yml
+++ b/cncfci.yml
@@ -3,7 +3,7 @@
   display_name: etcd
   sub_title: Key/Value Store
   project_url: "https://github.com/etcd-io/etcd"
-  stable_ref: "v3.4.12"
+  stable_ref: "v3.4.13"
   head_ref: "master"
   ci_system:
     -


### PR DESCRIPTION
## Description
  - v3.4.13 was released on 08/24/2020
  - update stable on production
  - this build will fail as their own travis-ci is in failed status for several of the build steps: https://travis-ci.com/github/etcd-io/etcd/builds/181139403

## Issues:

 https://github.com/vulk/cncf_ci/issues/344

## How has this been tested:

 - [ ]  Covered by existing integration testing
 - [ ]  Added integration testing to cover
 - [x]  Manually tested on dev.cncf.ci; will fail as their travis-ci shows failed status
 - [ ]  Tested with trigger client against
   - [x]  cidev.cncf.ci
   - [x]  dev.cncf.ci
   - [x]  staging.cncf.ci
   - [ ]  cncf.ci (production)
 - [ ]  Browser tested on staging.cncf.ci
 - [x]  Have not tested

## Types of changes:
 - [ ]  Bug fix (non-breaking change which fixes an issue)
 - [ ]  New feature (non-breaking change which adds functionality)
 - [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Version update

## Checklist:
  - [ ]  My change requires a change to the documentation
  - [ ]  I have updated the documentation accordingly
  - [x]  No updates required